### PR TITLE
getting-started: first-application: Updated doc to compile when copied

### DIFF
--- a/docs/getting-started/first-application.md
+++ b/docs/getting-started/first-application.md
@@ -69,11 +69,15 @@ const capy = @import("capy");
 pub usingnamespace capy.cross_platform;
 
 pub fn main() !void {
+	try capy.init();
+	
+	var window = try capy.Window.init();
 	window.setPreferredSize(800, 600);
 	try window.set(
     	capy.button(.{ .label = "A Button" })
 	);
 	window.show();
+	capy.runEventLoop();
 }
 ```
 


### PR DESCRIPTION
When I found the getting-started docs and started playing around with capy, I noticed that the button example did not compile as it was missing a few things. I added the window variable that was missing along with the backend init and event loop that was referenced in the previous examples. This should now compile with when copied and align with both what the image expects and continue to build on the other examples.